### PR TITLE
Add D-Link DIR-835

### DIFF
--- a/passwords.csv
+++ b/passwords.csv
@@ -2787,3 +2787,4 @@ xerox,xerox,,Multi,admin,admin,Admin,
 xyplex,switch,3.2,Console,<blank>,<blank>,Admin,
 zyxel,g-570s,,Multi,<blank>,admin,Admin,
 zyxel,prestige 300 series,zynos 2.*,,<blank>,1234,,
+D-Link,DIR-835,1.04,Multi,admin,<blank>,Admin,Default IP: 192.168.0.1


### PR DESCRIPTION
Added entry for D-Link device DIR-835:
D-Link,DIR-835,1.04,Multi,admin,<blank>,Admin,Default IP: 192.168.0.1
at line 2790