### PR TITLE
update raspberry pi note

### DIFF
--- a/passwords.csv
+++ b/passwords.csv
@@ -2138,7 +2138,7 @@ Ramp Networks,WebRamp,,,wradmin,trancell,,
 Rapid7 Inc,Metasploitable,2.0.0,Linux User (e.g. SSH & SFTP),msfadmin,msfadmin,root,
 RapidStream,RapidStream Appliances,,Multi,rsadmin,(null),Admin,
 Raritan,KVM Switches,,,admin,raritan,Admin,
-Raspberry Pi Foundation,Raspberry Pi OS,ANY,Linux User (e.g. SSH & SFTP),pi,raspberry,sudo access,https://www.raspberrypi.org/documentation/linux/usage/users.md
+Raspberry Pi Foundation,Raspberry Pi OS,ANY,Linux User (e.g. SSH & SFTP),pi,raspberry,sudo access,Until recently the default user/password combination was used. The default user is now set on first boot using a configuration wizard. Source: https://www.raspberrypi.com/documentation/computers/configuration.html#change-user-password
 RedHat,Piranha,6.2,Console,<blank>,Q,Interface,
 RedHat,Redhat 6.2,,HTTP,piranha,piranha,User,
 RedHat,Redhat 6.2,,HTTP,piranha,q,User,


### PR DESCRIPTION
According to the official documentation the default username/password combination was only used until recently. Nowadays this is set on first boot using a configuration wizard.
Source: https://www.raspberrypi.com/documentation/computers/configuration.html#change-user-password