### PR TITLE
update ubiquiti notes

### DIFF
--- a/passwords.csv
+++ b/passwords.csv
@@ -2520,7 +2520,7 @@ US Robotics,USR9110,,HTTP,admin,<blank>,Admin,default IP subnet: 192.168.1.0
 USR,TOTALswitch,Any,,<blank>,amber,,
 UTStarcom,B-NAS/B-RAS,1000,,dbase,dbase,,
 UTStarcom,B-NAS/B-RAS,1000,,guru,*3noguru,,
-Ubiquiti,All products,ANY,HTTP,ubnt,ubnt,Admin,Default IP: 192.168.1.1 (for Routers e.g. USG) or 192.168.1.20 (for radios, UniFi, cameras,...)
+Ubiquiti,All products,ANY,HTTP,ubnt,ubnt,Admin,Default IP: 192.168.1.1 (for Routers e.g. USG) or 192.168.1.20 (for radios; UniFi; cameras and more...)
 Unex,NexIP Routers,,,<blank>,password,,
 Unisys,ClearPath MCP,,Multi,ADMINISTRATOR,ADMINISTRATOR,Admin,
 Unisys,ClearPath MCP,,Multi,HTTP,HTTP,Web Server Administration,

--- a/passwords.csv
+++ b/passwords.csv
@@ -2520,7 +2520,7 @@ US Robotics,USR9110,,HTTP,admin,<blank>,Admin,default IP subnet: 192.168.1.0
 USR,TOTALswitch,Any,,<blank>,amber,,
 UTStarcom,B-NAS/B-RAS,1000,,dbase,dbase,,
 UTStarcom,B-NAS/B-RAS,1000,,guru,*3noguru,,
-Ubiquiti,All products,ANY,HTTP,ubnt,ubnt,Admin,
+Ubiquiti,All products,ANY,HTTP,ubnt,ubnt,Admin,Default IP: 192.168.1.1 (for Routers e.g. USG) or 192.168.1.20 (for radios, UniFi, cameras,...)
 Unex,NexIP Routers,,,<blank>,password,,
 Unisys,ClearPath MCP,,Multi,ADMINISTRATOR,ADMINISTRATOR,Admin,
 Unisys,ClearPath MCP,,Multi,HTTP,HTTP,Web Server Administration,


### PR DESCRIPTION
According to the Ubiquiti forum there are two default IP addresses: 

- 192.168.1.1 for routers such as PowerAPN and AirRouter
- 192.168.1.20 for radios, UniFi, cameras

Source: https://community.ui.com/questions/Factory-Default-IP-Address/b8cff4f3-d6c2-4956-b196-fd2b5da77bce#answer/a2a3daab-cf7c-4d1c-91ad-51d7b353334d